### PR TITLE
Fix for Issue #3

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TabGroupJumperVSIX
+{
+  /// <summary> Useful extension methods. </summary>
+  public static class Extensions
+  {
+    public static T GetService<T>(this IServiceProvider serviceProvider)
+      => (T)serviceProvider.GetService(typeof(T));
+  }
+}

--- a/src/NavigateTabGroups.csproj
+++ b/src/NavigateTabGroups.csproj
@@ -69,6 +69,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/TabGroupJump.cs
+++ b/src/TabGroupJump.cs
@@ -15,7 +15,6 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TextManager.Interop;
 using IServiceProvider = System.IServiceProvider;
 
 namespace TabGroupJumperVSIX
@@ -60,17 +59,11 @@ namespace TabGroupJumperVSIX
 
       this.package = package;
 
-      _tabGroupMoverLeftRight = new TabGroupMoverLeftRight();
-      _tabGroupMoverUpDown = new TabGroupMoverUpDown();
-      _tabGroupMoverNextPrevious = new TabGroupMoverNextPrevious();
+      _tabGroupMoverLeftRight = new TabGroupMoverLeftRight(ServiceProvider);
+      _tabGroupMoverUpDown = new TabGroupMoverUpDown(ServiceProvider);
+      _tabGroupMoverNextPrevious = new TabGroupMoverNextPrevious(ServiceProvider);
 
-      _tabGroupMoverLeftRight.Initialize(ServiceProvider);
-      _tabGroupMoverUpDown.Initialize(ServiceProvider);
-      _tabGroupMoverNextPrevious.Initialize(ServiceProvider);
-
-      OleMenuCommandService commandService =
-        ServiceProvider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
-      if (commandService != null)
+      if (ServiceProvider.GetService(typeof(IMenuCommandService)) is OleMenuCommandService commandService)
       {
         // Add the jump commands to the handler
         commandService.AddCommand(
@@ -97,7 +90,7 @@ namespace TabGroupJumperVSIX
     }
 
     /// <summary>
-    /// Gets the instance of the command.
+    /// Gets the instance of the package.
     /// </summary>
     public static TabGroupJump Instance { get; private set; }
 
@@ -124,13 +117,14 @@ namespace TabGroupJumperVSIX
     /// </summary>
     private abstract class TabGroupMover
     {
-      private IServiceProvider _serviceProvider;
+      private readonly IServiceProvider _serviceProvider;
+      private readonly IVsUIShell _uiShell;
 
-      /// <summary>
-      ///  We need a service provider and having an Initialize method makes for smaller derived classes.
-      /// </summary>
-      public void Initialize(IServiceProvider serviceProvider)
-        => _serviceProvider = serviceProvider;
+      protected TabGroupMover(IServiceProvider serviceProvider)
+      {
+        _serviceProvider = serviceProvider;
+        _uiShell = (IVsUIShell)serviceProvider.GetService(typeof(SVsUIShell));
+      }
 
       /// <summary>
       ///  How the document-windows should ordered.  They should be ordered such that when
@@ -139,7 +133,8 @@ namespace TabGroupJumperVSIX
       ///  should return true when moving down.
       /// </summary>
       /// <seealso cref="ShouldMoveForward"/>
-      protected abstract IEnumerable<Window> FilterAndSort(IEnumerable<Window> windows, Document activeDocument);
+      protected abstract IEnumerable<WindowData> FilterAndSort(IEnumerable<WindowData> windows,
+                                                               WindowData activeDocument);
 
       /// <summary>
       ///  True if the given command represents moving forward in the collection returned by
@@ -158,9 +153,23 @@ namespace TabGroupJumperVSIX
         DTE2 dte = (DTE2)_serviceProvider.GetService(typeof(DTE));
         int commandId = ((MenuCommand)sender).CommandID.ID;
 
-        var activeDocument = dte.ActiveDocument;
+        var activeWindows = GetWindowData(dte).ToList();
 
-        var topLevel = FilterAndSort(GetValidDocuments(dte), activeDocument)
+        WindowData activeWindow = null;
+
+        foreach (var windowData in activeWindows)
+        {
+          if (windowData.Window == dte.ActiveWindow)
+          {
+            activeWindow = windowData;
+            break;
+          }
+        }
+
+        if (activeWindow == null)
+          return;
+
+        var topLevel = FilterAndSort(activeWindows, activeWindow)
           .ToList();
 
         // for vertical tabs, t.Top might all be the same... not sure why.
@@ -184,112 +193,101 @@ namespace TabGroupJumperVSIX
           return;
 
         var isMovingForward = ShouldMoveForward(commandId);
-        var indexOfCurrentTabGroup = GetIndexOfDocument(topLevel, activeDocument, isMovingForward);
+        var indexOfCurrentTabGroup = GetIndexofActiveWindow(topLevel, dte.ActiveWindow);
 
         // get the tab to activate
         var offset = isMovingForward ? 1 : -1;
         int nextIndex = Clamp(topLevel.Count, indexOfCurrentTabGroup + offset);
 
         // and activate it
-        topLevel[nextIndex].Activate();
+        topLevel[nextIndex].Window.Activate();
       }
 
-      /// <summary>
-      ///  Gets the IVsTextView associated with the given document so that it can be measured.
-      /// </summary>
-      private IVsTextView GetTextView(Document document)
+      /// <summary> Get all of the Windows that have an associated frame. </summary>
+      private IEnumerable<WindowData> GetWindowData(DTE2 dte)
       {
-        uint itemID;
-        IVsWindowFrame windowFrame;
-        IVsUIHierarchy uiHierarchy;
+        var existingWindows = new HashSet<Window>(GetActiveWindows(dte));
 
-        // TODO there must be a better way of getting the IVsTextView
-        var isOpen = VsShellUtilities.IsDocumentOpen(_serviceProvider,
-                                                     document.FullName,
-                                                     Guid.Empty,
-                                                     out uiHierarchy,
-                                                     out itemID,
-                                                     out windowFrame);
+        var frames = GetFrames();
 
-        object data;
-
-        ErrorHandler.ThrowOnFailure(windowFrame.GetProperty(
-                                      (int)__VSFPROPID.VSFPROPID_DocView,
-                                      out data
-                                    ));
-
-        if (!(data is IVsTextView || data is IVsCodeWindow))
+        foreach (var frame in frames)
         {
+          if (frame.GetProperty((int)__VSFPROPID.VSFPROPID_ExtWindowObject, out var window) == 0
+              && window is Window typedWindow
+              && existingWindows.Contains(typedWindow)
+            )
+          {
+            yield return new WindowData(typedWindow, frame);
+          }
         }
-
-        return isOpen
-          ? VsShellUtilities.GetTextView(windowFrame)
-          : null;
       }
 
-      private static IEnumerable<Window> GetValidDocuments(DTE2 dte)
+      /// <summary> Gets all of the windows that are currently positioned with a valid Top or Left. </summary>
+      private IEnumerable<Window> GetActiveWindows(DTE2 dte)
       {
         // documents that are not the focused document in a group will have Top == 0 && Left == 0
-        return dte.Windows.Cast<Window>()
-                  .Where(w => w.Kind == "Document")
-                  .Where(w => w.Top != 0 || w.Left != 0);
+        return from window in dte.Windows.Cast<Window>()
+               where window.Kind == "Document"
+               where window.Top != 0 || window.Left != 0
+               select window;
       }
 
-      private int GetIndexOfDocument(List<Window> windows, Document activeDoc, bool isMovingForward)
+      /// <summary> Get all known <see cref="IVsWindowFrame"/>, lazily. </summary>
+      private IEnumerable<IVsWindowFrame> GetFrames()
       {
-        int activeIdx = 0;
+        var array = new IVsWindowFrame[1];
+        _uiShell.GetDocumentWindowEnum(out var frames);
 
-        // HACK: when we have a multi-pane editor (such as WPF design view + xml view), we'll have two
-        // entries for the same document.  This causes problems when we're moving through the list:
-        // Imagine that the multi-pane editor is at index N and N+1 (both the same document); when we
-        // move from N to N+1, no problem, but when we then try to move forward again, if we start the
-        // search for the "current" document at the beginning of the list, we'll think we're still at N
-        // instead of N+1.  So, instead when we're moving forward through the list, we start the search
-        // at the end of the list, and when we're moving backwards, we'll start the search at the
-        // beginning.
-        // 
-        // Note that this is a hack; we should be looking at the current editor window, not the current
-        // document; we can fix this if anyone ever complains.
-        // 
-        // (another way to fix it would be to ignore non-editor panes) 
-        if (isMovingForward)
+        while (true)
         {
-          for (int i = windows.Count - 1; i >= 0; --i)
-          {
-            if (windows[i].Document == activeDoc)
-            {
-              activeIdx = i;
-              break;
-            }
-          }
+          var errorCode = frames.Next(1, array, out _);
+          if (errorCode != VSConstants.S_OK)
+            break;
+
+          yield return array[0];
         }
-        else
+      }
+
+      private static int GetIndexofActiveWindow(List<WindowData> windows, Window activeWindow)
+      {
+        for (var i = 0; i < windows.Count; i++)
         {
-          for (int i = 0; i < windows.Count; ++i)
-          {
-            if (windows[i].Document == activeDoc)
-            {
-              activeIdx = i;
-              break;
-            }
-          }
+          var data = windows[i];
+          if (data.Window == activeWindow)
+            return i;
         }
 
-        return activeIdx;
+        return 0;
       }
 
       /// <summary> Clamp the given value to be between 0 and <paramref name="count"/>. </summary>
       private static int Clamp(int count, int number)
         => (number < 0 ? number + count : number) % count;
+    }
+
+    internal class WindowData
+    {
+      public Window Window { get; }
+      public IVsWindowFrame AssociatedFrame { get; }
+
+      private RECT? _measuredRect;
+
+      public WindowData(Window window, IVsWindowFrame associatedFrame)
+      {
+        Window = window;
+        AssociatedFrame = associatedFrame;
+        Bounds = MeasureBounds();
+      }
+
+      public RECT Bounds { get; }
 
       /// <summary> Measure the bounds of the given window </summary>
-      internal RECT MeasureBounds(Window window)
+      private RECT MeasureBounds()
       {
-        var textView = GetTextView(window.Document);
+        var window = Window;
+        var textView = VsShellUtilities.GetTextView(AssociatedFrame);
 
-        RECT rect;
-
-        if (textView != null && GetWindowRect(textView.GetWindowHandle(), out rect))
+        if (textView != null && GetWindowRect(textView.GetWindowHandle(), out var rect))
         {
           return rect;
         }
@@ -311,13 +309,19 @@ namespace TabGroupJumperVSIX
     /// <summary> Command implementation for moving up/down. </summary>
     private class TabGroupMoverUpDown : TabGroupMover
     {
+      public TabGroupMoverUpDown(IServiceProvider serviceProvider)
+        : base(serviceProvider)
+      {
+      }
+
       /// <inheritdoc />
-      protected override IEnumerable<Window> FilterAndSort(IEnumerable<Window> windows, Document activeDocument)
+      protected override IEnumerable<WindowData> FilterAndSort(IEnumerable<WindowData> windows,
+                                                               WindowData activeWindow)
         => from w in windows
-           where w.Document == activeDocument
-                 || w.Left == activeDocument.ActiveWindow.Left
-           let rect = MeasureBounds(w)
-           orderby rect.left, rect.top
+           where w == activeWindow
+                  // only return those that aren't aligned vertically
+                 || w.Bounds.left == activeWindow.Bounds.left
+           orderby w.Bounds.left, w.Bounds.top
            select w;
 
       /// <inheritdoc />
@@ -328,14 +332,22 @@ namespace TabGroupJumperVSIX
     /// <summary> Command implementation for moving left/right. </summary>
     private class TabGroupMoverLeftRight : TabGroupMover
     {
+      public TabGroupMoverLeftRight(IServiceProvider serviceProvider)
+        : base(serviceProvider)
+      {
+      }
+
       /// <inheritdoc />
-      protected override IEnumerable<Window> FilterAndSort(IEnumerable<Window> windows, Document activeDocument)
-        => from w in windows
-           where w.Document == activeDocument
-                 || w.Left != activeDocument.ActiveWindow.Left
-           let rect = MeasureBounds(w)
-           orderby rect.left, rect.top
-           select w;
+      protected override IEnumerable<WindowData> FilterAndSort(IEnumerable<WindowData> windows,
+                                                               WindowData activeWindow)
+      {
+        return from w in windows
+               // only return those that aren't aligned vertically
+               where w == activeWindow
+                     || w.Bounds.left != activeWindow.Bounds.left
+               orderby w.Bounds.left, w.Bounds.top
+               select w;
+      }
 
       /// <inheritdoc />
       protected override bool ShouldMoveForward(int commandId)
@@ -345,11 +357,16 @@ namespace TabGroupJumperVSIX
     /// <summary> Command implementation for moving next/previous. </summary>
     private class TabGroupMoverNextPrevious : TabGroupMover
     {
+      public TabGroupMoverNextPrevious(IServiceProvider serviceProvider)
+        : base(serviceProvider)
+      {
+      }
+
       /// <inheritdoc />
-      protected override IEnumerable<Window> FilterAndSort(IEnumerable<Window> windows, Document activeDocument)
+      protected override IEnumerable<WindowData> FilterAndSort(IEnumerable<WindowData> windows,
+                                                               WindowData activeWindow)
         => from w in windows
-           let rect = MeasureBounds(w)
-           orderby rect.left, rect.top
+           orderby w.Bounds.left, w.Bounds.top
            select w;
 
       /// <inheritdoc />

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="E637A336-69E4-4FB3-8A53-9492EBDAFB3B" Version="1.2.1" Language="en-US" Publisher="Mackenzie Zastrow" />
-    <DisplayName>Navigate Tab Groups</DisplayName>
-    <Description xml:space="preserve">Exposes commands for navigating to different tab groups, allowing keyboard shortcuts to be assigned to each command</Description>
-    <MoreInfo>https://github.com/zastrowm/vs-NavigateTabGroups</MoreInfo>
-    <License>license.txt</License>
-    <GettingStartedGuide>https://github.com/zastrowm/vs-NavigateTabGroups</GettingStartedGuide>
-    <Tags>tabs; tab groups; keyboard; keyboard shortcuts;</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.IntegratedShell" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="E637A336-69E4-4FB3-8A53-9492EBDAFB3B" Version="1.3.0" Language="en-US" Publisher="Mackenzie Zastrow" />
+        <DisplayName>Navigate Tab Groups</DisplayName>
+        <Description xml:space="preserve">Exposes commands for navigating to different tab groups, allowing keyboard shortcuts to be assigned to each command</Description>
+        <MoreInfo>https://github.com/zastrowm/vs-NavigateTabGroups</MoreInfo>
+        <License>license.txt</License>
+        <GettingStartedGuide>https://github.com/zastrowm/vs-NavigateTabGroups</GettingStartedGuide>
+        <Tags>tabs; tab groups; keyboard; keyboard shortcuts;</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.IntegratedShell" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Issue #3 reports two problems :

    1. If a given document is opened multiple times, the order becomes messed up
    2. If multiple windows are opened, the order becomes messed up

## 1. Problem Diagnosis

The root cause was the way that we measured windows/editors.  To measure a window, we were attempting to map a document to a "frame" which we would then use for measuring.  However, the mapping from documents to frames was a 1->* relationship, which meant that we had to pick a designated frame as the one to measure, which led to us skipping duplicates of a document - as we would basically not even see the associated frames.

## 1. Solution 

We needed to find a better way to measure the windows/editors.  Now we enumerate all open "frames", filter down to only the active windows/frames that we care about, and then measure the frame, which gives us much better measurements.

## 2. Problem Diagnosis

We were sorting/filtering by a crappy "measurement", which for horizontal split editors, excluded all other panes in the tab.  

## 2. Solution

Given that we now have a better "measurement" because of the fix for (1), we can sort/filter based on the accurate measurements instead.