### PR TITLE
Fix for Issue #5 - Fix active tabs detection

### DIFF
--- a/src/NavigateTabGroups.csproj
+++ b/src/NavigateTabGroups.csproj
@@ -132,6 +132,10 @@
       <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Platform.WindowManagement, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Microsoft.VisualStudio.Platform.WindowManagement.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.3.25407\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
For detecting which tab was the *active* tab in a tab group, we previously used `window.Top != 0 || window.Left != 0`.  This works for most windows, until of course, you position a floating tab group into the upper left.

A straightforward way to detect the _active_ tab eludes me, but I did find [CloseTabsToRight](https://github.com/billpratt/CloseTabsToRight) by @billpratt, which ends up using the concrete class `WindowFrame`.  This class has an `OnScreen` attribute which seems to indicate whether a frame is active or not.

So switch to using `WindowFrame.OnScreen` for detecting active windows/tabs.